### PR TITLE
reproducible dev environment via nix-shell

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,22 @@
+{ pkgs ? import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/52dc75a4fee3fdbcb792cb6fba009876b912bfe0.tar.gz") {} }:
+
+let coq = pkgs.coq.override { customOCamlPackages = pkgs.ocamlPackages; };
+in
+
+pkgs.mkShell {
+  buildInputs = with pkgs; [
+    cargo
+    coq
+    dune_2
+    just
+    libffi
+    libiconv
+    llvmPackages_13.llvm
+    (runCommand "lli-13" {} "mkdir -p $out/bin && ln -s ${llvmPackages_13.llvm}/bin/lli $out/bin/lli-13")
+    ocaml
+    ocamlPackages.zarith
+  ];
+
+  OCAMLPATH = "${coq}/lib:${pkgs.ocamlPackages.zarith}/lib/ocaml/4.13.1/site-lib";
+  RUSTFLAGS = "-l LLVM-13";
+}


### PR DESCRIPTION
Hi, Blaine!

This is a `shell.nix` file that makes it easy for anyone to reproducibly run your code. For example, both of these work:

```
nix-shell --run "just build"
```

or

```
nix-shell --run "just lab"
```

All anyone needs to do to get those commands to work (on Linux or MacOS) is [install nix](https://nixos.org/download.html).